### PR TITLE
Add B partition for potential A/B setup

### DIFF
--- a/features/orabos/file.include/etc/repart.d/root_b.conf
+++ b/features/orabos/file.include/etc/repart.d/root_b.conf
@@ -1,0 +1,2 @@
+[Partition]
+Type=root


### PR DESCRIPTION
Simply adding a second root.conf instructs systemd-repart to create another root parition of equal size.